### PR TITLE
add of singleton, bind param in login and escape string function

### DIFF
--- a/backend/funcs.php
+++ b/backend/funcs.php
@@ -3,6 +3,8 @@ namespace funcs;
 
 class Functions
 {
+    private static $conn;
+
     public static function conn()
     {
         /* MySQL VARIABLES */
@@ -11,11 +13,23 @@ class Functions
         $db_pass = 'root';
         $db_name = 'kat_status';
 
-        return mysqli_connect($db_serv, $db_user, $db_pass, $db_name);
+        if (!self::$conn) {
+            self::$conn = mysqli_connect($db_serv, $db_user, $db_pass, $db_name);
+        }
+
+        return self::$conn;
     }
 
     public static function query($db_conn, $sql)
     {
         return mysqli_query($db_conn, $sql);
+    }
+    public static function execute_stmt($stmt)
+    {
+        return mysqli_stmt_execute($stmt);
+    }
+    public static function escape_string($string)
+    {
+        return mysqli_real_escape_string(self::conn(), $string);
     }
 }

--- a/login/index.php
+++ b/login/index.php
@@ -23,8 +23,14 @@
       }
       if (isset($_POST['signup']) && $_POST['username'] !== '' && $_POST['password'] !== '') {
           $new_pass = password_hash($_POST['password'], CRYPT_BLOWFISH);
-          $sql = "INSERT INTO `users` (username, password) VALUES ('".mysqli_real_escape_string($db_conn, $_POST['username'])."', '".mysqli_real_escape_string($db_conn, $new_pass)."')";
-          $res = \funcs\Functions::query($db_conn, $sql);
+          $sql = "INSERT INTO `users` (username, password) VALUES (?, ?)";
+          $stmt = mysqli_prepare($db_conn, $sql);
+
+          $user_cleaned = \funcs\Functions::escape_string($_POST['username']);
+          $pass_cleaned = \funcs\Functions::escape_string($new_pass);
+          mysqli_stmt_bind_param($stmt, "ss", $user_cleaned, $pass_cleaned);
+
+          $res = \funcs\Functions::execute_stmt($stmt);
           $signedup = ($res) ? true : false;
       }
     ?>


### PR DESCRIPTION
partially closes #2 because this part is not implemented with parameter binding, later I'll work on it 

``` php
      if (isset($_POST['login']) && $_POST['username'] !== '' && $_POST['password'] !== '') {
          $sql = "SELECT password FROM `users` WHERE username='".mysqli_real_escape_string($db_conn, $_POST['username'])."'";
          $res = \funcs\Functions::query($db_conn, $sql);
          while ($row = mysqli_fetch_assoc($res)) {
              $hash = $row['password'];
          }
```

Also added a singleton pattern to the connection, to remove the need to pass the connection reference back and forth.
